### PR TITLE
/login now responds with a carbide license as a json object

### DIFF
--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -24,7 +24,7 @@ func loginHandler(licensePubkeys []*rsa.PublicKey) http.HandlerFunc {
 		if err := utils.DecodeJSONObject(w, r, &license); err != nil {
 			return
 		}
-		if err := middleware.Login(w, license, licensePubkeys); err != nil {
+		if err := middleware.Login(w, *license.LicenseString, licensePubkeys); err != nil {
 			return
 		}
 	}

--- a/pkg/api/carbide.go
+++ b/pkg/api/carbide.go
@@ -25,7 +25,7 @@ func createCarbideAccountHandler(clientFactory *armcontainerregistry.ClientFacto
 			return
 		}
 		expiry := time.Now().Add(time.Hour * 24 * time.Duration(*newLicense.DaysTillExpiry))
-		newLicense.License, err = license.CreateCarbideLicense(privateKey, *newLicense.NodeCount, *newLicense.CustomerID, expiry)
+		newLicense.LicenseString, err = license.CreateCarbideLicense(privateKey, *newLicense.NodeCount, *newLicense.CustomerID, expiry)
 		if err != nil {
 			log.Error(err)
 			utils.HttpJSONError(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -2,6 +2,7 @@ package license
 
 import (
 	"crypto/rsa"
+	"math"
 	"time"
 
 	golicense "github.com/ebauman/golicense/pkg/license"
@@ -37,7 +38,7 @@ func ParseCarbideLicense(licenseString string, licensePubkeys []*rsa.PublicKey) 
 	}
 	var parsedLicense CarbideLicense
 	parsedLicense.CustomerID = &license.Licensee
-	daysTillExpiry := int(license.NotAfter.Sub(time.Now()).Hours() / 24)
+	daysTillExpiry := int(math.Ceil(license.NotAfter.Sub(time.Now()).Hours() / 24))
 	parsedLicense.DaysTillExpiry = &daysTillExpiry
 	nodeCount := license.Grants["compliance.cattle.io/stigatron"]
 	parsedLicense.NodeCount = &nodeCount

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -30,11 +30,16 @@ func CreateCarbideLicense(privateKey *rsa.PrivateKey, nodeCount int, customerID 
 	return &keystring, nil
 }
 
-// returns customer ID if valid, err if not
-func ParseCarbideLicense(licenseString string, licensePubkeys []*rsa.PublicKey) (*string, error) {
+func ParseCarbideLicense(licenseString string, licensePubkeys []*rsa.PublicKey) (CarbideLicense, error) {
 	license, err := golicense.ParseLicenseKey([]byte(licenseString), licensePubkeys)
 	if err != nil {
-		return nil, err
+		return CarbideLicense{}, err
 	}
-	return &license.Licensee, nil
+	var parsedLicense CarbideLicense
+	parsedLicense.CustomerID = &license.Licensee
+	daysTillExpiry := int(license.NotAfter.Sub(time.Now()).Hours() / 24)
+	parsedLicense.DaysTillExpiry = &daysTillExpiry
+	nodeCount := license.Grants["compliance.cattle.io/stigatron"]
+	parsedLicense.NodeCount = &nodeCount
+	return parsedLicense, nil
 }

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -34,3 +34,42 @@ func TestCreateCarbideLicense(t *testing.T) {
 	}
 	t.Logf("Generated license: %s", *license)
 }
+
+func TestParseCarbideLicense(t *testing.T) {
+	nodeCount := 25
+	daysTillExpiry := 167
+	customerID := CUSTOMER_ID_PREFIX + randString(5)
+	expiry := time.Now().Add(time.Hour * 24 * time.Duration(daysTillExpiry))
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	license, err := CreateCarbideLicense(privateKey, nodeCount, customerID, expiry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedCarbideLicense, err := ParseCarbideLicense(*license, []*rsa.PublicKey{&privateKey.PublicKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	validCarbideLicense := CarbideLicense{
+		NodeCount:      &nodeCount,
+		DaysTillExpiry: &daysTillExpiry,
+		CustomerID:     &customerID,
+	}
+	if *parsedCarbideLicense.CustomerID != *validCarbideLicense.CustomerID {
+		t.Errorf("parsedCarbideLicense.CustomerID: %s\nvalidCarbideLicense.CustomerID: %s", *parsedCarbideLicense.CustomerID, *validCarbideLicense.CustomerID)
+	} else {
+		t.Logf("parsed customerID is valid")
+	}
+	if *parsedCarbideLicense.DaysTillExpiry != *validCarbideLicense.DaysTillExpiry {
+		t.Errorf("parsedCarbideLicense.DaysTillExpiry: %d\nvalidCarbideLicense.DaysTillExpiry: %d", *parsedCarbideLicense.DaysTillExpiry, *validCarbideLicense.DaysTillExpiry)
+	} else {
+		t.Logf("parsed daysTillExpiry is valid")
+	}
+	if *parsedCarbideLicense.NodeCount != *validCarbideLicense.NodeCount {
+		t.Errorf("parsedCarbideLicense.NodeCount: %d\nvalidCarbideLicense.NodeCount: %d", *parsedCarbideLicense.NodeCount, *validCarbideLicense.NodeCount)
+	} else {
+		t.Logf("parsed nodeCount is valid")
+	}
+}

--- a/pkg/license/types.go
+++ b/pkg/license/types.go
@@ -9,7 +9,7 @@ type CarbideLicense struct {
 	DaysTillExpiry *int
 	NodeCount      *int
 
-	License  *string
-	Token    *armcontainerregistry.Token
-	Password *armcontainerregistry.TokenPassword
+	LicenseString *string                             `json:"license,omitempty"`
+	Token         *armcontainerregistry.Token         `json:"token,omitempty"`
+	Password      *armcontainerregistry.TokenPassword `json:"password,omitempty"`
 }


### PR DESCRIPTION
provides decoded license data for frontend consumption